### PR TITLE
Add the "one possible deduction tree" data structure to both the naive and fast earley

### DIFF
--- a/src/cfg.py
+++ b/src/cfg.py
@@ -4,9 +4,10 @@ We keep the representation of various objects related to the context-free gramma
 
 from dataclasses import dataclass, field
 from typing import Set, List, Tuple, Union, TypeAlias, Self, Optional
-from node import Node, NonTerminal, Terminal
 
 from bidict import bidict
+
+from node import Node, NonTerminal, Terminal
 
 Symbol: TypeAlias = int
 """A `Symbol` represents a terminal or non-terminal symbol in the grammar.
@@ -124,7 +125,7 @@ class Grammar:
         return [x for x in [self.fmt_rules_for(sym) for sym in range(len(self.rules))] if x]
 
     def fmt_all_symbols(self) -> List[str]:
-        return [f"{sym}{'*' if symid in self.terminals else ''}" for symid, sym in self.symbols.items()]
+        return [f"{sym.symbol()}{'*' if symid in self.terminals else ''}" for symid, sym in self.symbols.items()]
 
     def fmt_point(self, pt: Union[GrammarPoint, StarPoint], sep: Optional[str] = None) -> str:
         sep = sep if sep is not None else ''

--- a/src/deduction.py
+++ b/src/deduction.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Tuple, Union, Self, List
 
 from cfg import GrammarPoint, Symbol, Grammar
+from node import InputString
 
 
 @dataclass(frozen=True)
@@ -14,7 +15,7 @@ class DeductionSpan:
         if type(self.point) is GrammarPoint:
             return f"{grammar.fmt_point(self.point)} [{b}, {e})"
         else:
-            return f"{grammar.symbols[self.point]} [{b}, {e})"
+            return f"{grammar.symbols[self.point].symbol()} [{b}, {e})"
 
 
 @dataclass(frozen=True)
@@ -22,11 +23,11 @@ class DeductionNode:
     span: DeductionSpan
     children: List[Self]
 
-    def fmt_tree(self, grammar: Grammar, depth: int = 0, s: Union[str, None] = None) -> List[str]:
+    def fmt_tree(self, grammar: Grammar, depth: int = 0, s: Union[InputString, None] = None) -> List[str]:
         b, e = self.span.span
         me = f"{'\t' * depth}{self.span.fmt(grammar)}"
         if s is not None:
-            me = f"{me} {s[b:e]}"
+            me = f"{me} {s.sep.join([c.symbol() for c in s.nodes[b:e]])}"
         nlist = [me]
         for c in self.children:
             nlist.extend(c.fmt_tree(grammar, depth + 1, s))

--- a/src/deduction.py
+++ b/src/deduction.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from typing import Tuple, Union, Self, List
+
+from cfg import GrammarPoint, Symbol, Grammar
+
+
+@dataclass(frozen=True)
+class DeductionSpan:
+    point: Union[GrammarPoint, Symbol]
+    span: Tuple[int, int]
+
+    def fmt(self, grammar: Grammar) -> str:
+        b, e = self.span
+        if type(self.point) is GrammarPoint:
+            return f"{grammar.fmt_point(self.point)} [{b}, {e})"
+        else:
+            return f"{grammar.symbols[self.point]} [{b}, {e})"
+
+
+@dataclass(frozen=True)
+class DeductionNode:
+    span: DeductionSpan
+    children: List[Self]
+
+    def fmt_tree(self, grammar: Grammar, depth: int = 0, s: Union[str, None] = None) -> List[str]:
+        b, e = self.span.span
+        me = f"{'\t' * depth}{self.span.fmt(grammar)}"
+        if s is not None:
+            me = f"{me} {s[b:e]}"
+        nlist = [me]
+        for c in self.children:
+            nlist.extend(c.fmt_tree(grammar, depth + 1, s))
+        return nlist

--- a/src/deduction.py
+++ b/src/deduction.py
@@ -1,19 +1,21 @@
 from dataclasses import dataclass
 from typing import Tuple, Union, Self, List
 
-from cfg import GrammarPoint, Symbol, Grammar
+from cfg import GrammarPoint, Symbol, Grammar, StarPoint
 from node import InputString
 
 
 @dataclass(frozen=True)
 class DeductionSpan:
-    point: Union[GrammarPoint, Symbol]
+    point: Union[GrammarPoint, StarPoint, Symbol]
     span: Tuple[int, int]
 
     def fmt(self, grammar: Grammar) -> str:
         b, e = self.span
         if type(self.point) is GrammarPoint:
             return f"{grammar.fmt_point(self.point)} [{b}, {e})"
+        elif type(self.point) is StarPoint:
+            return f"{grammar.symbols[self.point.sym].symbol()}★ [{b}, {e})"
         else:
             return f"{grammar.symbols[self.point].symbol()} [{b}, {e})"
 

--- a/src/fast_earley.py
+++ b/src/fast_earley.py
@@ -1,12 +1,14 @@
 """
 The "fast" implementation of the Earley algorithm.
-TODO: Some of the data types and methods are duplicated with the naive version. Perhaps it would be nicer to have a common interface.
+TODO: Some of the data types and methods are duplicated with the naive version.
+      Perhaps it would be nicer to have a common interface.
 """
 
 from dataclasses import dataclass
-from typing import Set, List, Tuple, TypeAlias, Self, Union
+from typing import Set, List, Tuple, TypeAlias, Self, Union, Dict
 
 from cfg import GrammarPoint, Grammar, StarPoint, Symbol
+from deduction import DeductionSpan, DeductionNode
 from node import NonTerminal, Terminal
 
 
@@ -24,6 +26,9 @@ class Item:
         PRE: `dot` must _not_ be at or past the end of the rule."""
         return Item(self.point.proceed(), self.beg)
 
+    def deduction_span(self, end: int) -> DeductionSpan:
+        return DeductionSpan(self.point, (self.beg, end))
+
 
 State: TypeAlias = Set[Item]
 """A `State` is the set of all items (i.e. partially parsed rules) to be considered
@@ -31,6 +36,10 @@ for parsing the terminal symbol at a particular point in the input string."""
 Chart: TypeAlias = List[State]
 """A `Chart` is the list of all the states for the input, with an extra state for the very
 beginning of the string (i.e. the chart has a length of `n+1` where `n` is the input size)."""
+DeductionChart: TypeAlias = Dict[DeductionSpan, DeductionSpan]
+"""For an item `key`, returns one possible item `value`, the completion of which proves of this item.
+The span of the prior partial parse can be computed from `key` and `value`.
+TODO: Keeping a hashmap isn't very performant. Consider finding an alternative."""
 
 
 @dataclass
@@ -39,10 +48,12 @@ class Earley:
     in a particular grammar with the Earley algorithm."""
     grammar: Grammar
     chart: Chart
+    deduced_by: DeductionChart
 
     def __init__(self, g: Grammar):
         self.grammar = g
         self.chart = [set()]
+        self.deduced_by = dict()
         start = self.grammar.symbols.inverse[NonTerminal("<start>")]
         for rule in range(len(self.grammar.rules[start])):
             self.chart[0].add(Item(GrammarPoint(start, rule, 0), 0))
@@ -75,10 +86,28 @@ class Earley:
                         and cit.point.sym == it.point.sym)
                     # But these items still belongs to the current state, since no input symbol was consumed here.
                     old.update(more)
+
+                    # Now, keep track of the deduction tree.
+                    # The item `it` completes the item `nit` (it is assumed that `it` was predicted by the symbol right
+                    # after the `dot` in `nit`). So, the partial parse of `nit` is deduced by the full parse of `it`,
+                    # unless `nit` is already claimed.
+                    it_span = it.deduction_span(cur_pos)
+                    for nit in more:
+                        nit_span = nit.deduction_span(cur_pos)
+                        if nit_span not in self.deduced_by:
+                            self.deduced_by[nit_span] = it_span
                 elif dot_sym == next_sym:
                     # Scan: This item was waiting for this particular terminal symbol at this location, so it can
                     # proceed.
-                    new.add(it.proceed())
+                    nit = it.proceed()
+                    new.add(nit)
+
+                    # Now, keep track of the deduction tree.
+                    # Again, the partial parse of `nit` is deduced by a single symbol `dot_sym`,
+                    # unless `nit` is already claimed.
+                    nit_span = nit.deduction_span(cur_pos + 1)
+                    if nit_span not in self.deduced_by:
+                        self.deduced_by[nit_span] = DeductionSpan(dot_sym, (cur_pos, cur_pos + 1))
                 elif dot_sym not in self.grammar.terminals:
                     # Predict Star: If `dot_sym` is non-terminal, then we need to expand the item further. But in this
                     # version, we always expand to a star item first.
@@ -97,6 +126,15 @@ class Earley:
                         and self.grammar.get_symbol_at_point(cit.point) == it.point.sym)
                     # Again, no input symbol was consumed, so these also belong to the current state.
                     old.update(more)
+
+                    # Now, keep track of the deduction tree.
+                    # As before, the partial parse of `nit` is deduced by the full parse of `it`,
+                    # unless `nit` is already claimed.
+                    it_span = it.deduction_span(cur_pos)
+                    for nit in more:
+                        nit_span = nit.deduction_span(cur_pos)
+                        if nit_span not in self.deduced_by:
+                            self.deduced_by[nit_span] = it_span
                 else:
                     # Predict: Expand the star item into a proper partial-parse item.
                     more = set(
@@ -138,3 +176,51 @@ class Earley:
         # TODO: Can this be done better?
         if c != Terminal("\0"):
             self.chart.append(new)
+
+    def trace_deduction(self, it: DeductionSpan) -> DeductionNode:
+        """Trace back one possible deduction tree rooted at `it` and return that root."""
+
+        # We do this recursively. First we create an empty node for `it`.
+        beg, end = it.span
+        node = DeductionNode(it, [])
+        if type(it.point) is GrammarPoint:
+            # For a production rule (can be partially parsed), we walk `dot` backward on the rule, starting at the dot.
+            for cdot in range(it.point.dot, 0, -1):
+                # At each step, we find out the deduction of the particular symbol in the rule we are right now on.
+                # This symbol must have been deduced and that deduction tree will become the subtree of `node`.
+                cit = GrammarPoint(it.point.sym, it.point.rule, cdot)  # a version of `it` with the dot at `cdot`.
+                cit_span = DeductionSpan(cit, (beg, end))
+
+                # Find out how `cit` was deduced.
+                by = self.deduced_by[cit_span]
+                assert cit_span != by  # We don't expect any "self deduction"
+                by_subtree = self.trace_deduction(by)
+
+                # Make the deduction tree of `cit` a subtree of the deduction of `it`.
+                # Note that we are walking back but building the `children` list forward. We'll have to reverse that.
+                node.children.append(by_subtree)
+                # Also, the deduction of `cit` already covers some part of the span.
+                # We only want the deduction for the remainder of the span as we walk back.
+                end = by.span[0]
+            # Reverse the `children` list which we built in forward direction when walking back on the rule.
+            node.children.reverse()
+        elif type(it.point) is StarPoint:
+            # We have a single symbol for a star rule. So, we just need to find out that singular deduction subtree.
+            # Find out how `it` was deduced.
+            by = self.deduced_by[it]
+            assert it != by  # We don't expect any "self deduction"
+            by_subtree = self.trace_deduction(by)
+
+            # Make the deduction tree of `cit` a subtree of the deduction of `it`.
+            node.children.append(by_subtree)
+        else:
+            # If `it` corresponds to just a terminal symbol then there is no subtree.
+            pass
+        return node
+
+    def complete_items(self, at: Union[int, None] = None) -> List[DeductionSpan]:
+        if at is None:
+            at = len(self.chart) - 1  # the current location at the input
+        return [c.deduction_span(at) for c in self.chart[at]
+                if c.point.sym == self.grammar.symbols.inverse[NonTerminal("<start>")]
+                and self.grammar.get_symbol_at_point(c.point) is None]

--- a/src/fast_earley.py
+++ b/src/fast_earley.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import Set, List, Tuple, TypeAlias, Self, Union
 
 from cfg import GrammarPoint, Grammar, StarPoint, Symbol
-from node import Node, NonTerminal, Terminal
+from node import NonTerminal, Terminal
 
 
 @dataclass(frozen=True)

--- a/src/naive_earley.py
+++ b/src/naive_earley.py
@@ -1,13 +1,12 @@
 """
 The "naive" implementation of the Earley algorithm.
 """
-from copy import deepcopy, copy
 from dataclasses import dataclass
 from typing import Set, List, Tuple, TypeAlias, Self, Dict, Union
 
 from cfg import GrammarPoint, Grammar, Symbol
-from node import Node, Terminal, NonTerminal
 from deduction import DeductionSpan, DeductionNode
+from node import Terminal, NonTerminal
 
 
 @dataclass(frozen=True)
@@ -155,5 +154,5 @@ class Earley:
         if at is None:
             at = len(self.chart) - 1  # the current location at the input
         return [c.deduction_span(at) for c in self.chart[at]
-                if c.point.sym == self.grammar.symbols.inverse["<start>"]
+                if c.point.sym == self.grammar.symbols.inverse[NonTerminal("<start>")]
                 and self.grammar.get_symbol_at_point(c.point) is None]

--- a/src/naive_earley.py
+++ b/src/naive_earley.py
@@ -1,12 +1,13 @@
 """
 The "naive" implementation of the Earley algorithm.
 """
-
+from copy import deepcopy, copy
 from dataclasses import dataclass
-from typing import Set, List, Tuple, TypeAlias, Self
+from typing import Set, List, Tuple, TypeAlias, Self, Dict, Union
 
 from cfg import GrammarPoint, Grammar, Symbol
 from node import Node, Terminal, NonTerminal
+from deduction import DeductionSpan, DeductionNode
 
 
 @dataclass(frozen=True)
@@ -22,6 +23,9 @@ class Item:
         PRE: `dot` must _not_ be at or past the end of the rule."""
         return Item(self.point.proceed(), self.beg)
 
+    def deduction_span(self, end: int) -> DeductionSpan:
+        return DeductionSpan(self.point, (self.beg, end))
+
 
 State: TypeAlias = Set[Item]
 """A `State` is the set of all items (i.e. partially parsed rules) to be considered
@@ -29,6 +33,10 @@ for parsing the terminal symbol at a particular point in the input string."""
 Chart: TypeAlias = List[State]
 """A `Chart` is the list of all the states for the input, with an extra state for the very
 beginning of the string (i.e. the chart has a length of `n+1` where `n` is the input size)."""
+DeductionChart: TypeAlias = Dict[DeductionSpan, DeductionSpan]
+"""For an item `key`, returns one possible item `value`, the completion of which proves of this item.
+The span of the prior partial parse can be computed from `key` and `value`.
+TODO: Keeping a hashmap isn't very performant. Consider finding an alternative."""
 
 
 @dataclass
@@ -37,10 +45,12 @@ class Earley:
     in a particular grammar with the Earley algorithm."""
     grammar: Grammar
     chart: Chart
+    deduced_by: DeductionChart
 
     def __init__(self, g: Grammar):
         self.grammar = g
         self.chart = [set()]
+        self.deduced_by = dict()
         start = self.grammar.symbols.inverse[NonTerminal("<start>")]
         for rule in range(len(self.grammar.rules[start])):
             self.chart[0].add(Item(GrammarPoint(start, rule, 0), 0))
@@ -67,9 +77,20 @@ class Earley:
                     self.grammar.get_symbol_at_point(cit.point) == it.point.sym)
                 # But these items still belongs to the current state, since no input symbol was consumed here.
                 old.update(more)
+                # The item `it` completes the item `nit` (it is assumed that `it` was predicted by the symbol right
+                # after the `dot` in `nit`).
+                it_span = it.deduction_span(cur_pos)
+                for nit in more:
+                    nit_span = nit.deduction_span(cur_pos)
+                    if nit_span not in self.deduced_by:
+                        self.deduced_by[nit_span] = it_span
             elif dot_sym == next_sym:
                 # Scan: This item was waiting for this particular terminal symbol at this location, so it can proceed.
-                new.add(it.proceed())
+                nit = it.proceed()
+                new.add(nit)
+                nit_span = nit.deduction_span(cur_pos + 1)
+                if nit_span not in self.deduced_by:
+                    self.deduced_by[nit_span] = DeductionSpan(dot_sym, (cur_pos, cur_pos + 1))
             elif dot_sym not in self.grammar.terminals:
                 # Predict: If `dot_sym` is non-terminal, then we need to expand the item further.
                 more = set(
@@ -80,9 +101,10 @@ class Earley:
         return old, new
 
     def feed(self, c: Terminal):
-        assert isinstance(c, Terminal), f'expected a Terminal, got {type(c)}'
         """_Feed_ the parser one terminal symbol `c`, one that comes after all the symbols it had been
         fed so far. This generates additional states according to the Earley algorithm."""
+        assert isinstance(c, Terminal), f'expected a Terminal, got {type(c)}'
+
         cid = self.grammar.terminal_symbol(c)  # the current terminal symbol's integer representation
         cur = len(self.chart) - 1  # the current location at the input
         cur_state = self.chart[cur]  # the items that need processing
@@ -111,3 +133,27 @@ class Earley:
         # TODO: Can this be done better?
         if c != Terminal("\0"):
             self.chart.append(new)
+
+    def trace_deduction(self, it: DeductionSpan) -> DeductionNode:
+        beg, end = it.span
+        node = DeductionNode(it, [])
+        if type(it.point) is GrammarPoint:
+            for dot in range(it.point.dot, 0, -1):
+                pt = GrammarPoint(it.point.sym, it.point.rule, dot)
+                t = DeductionSpan(pt, (beg, end))
+                # print('|', t.fmt(self.grammar), 'for', it.fmt(self.grammar))
+                by = self.deduced_by[t]
+                # print('|\tby', by.fmt(self.grammar))
+                if t != by:
+                    c = self.trace_deduction(by)
+                    node.children.append(c)
+                end = by.span[0]
+            node.children.reverse()
+        return node
+
+    def complete_items(self, at: Union[int, None] = None) -> List[DeductionSpan]:
+        if at is None:
+            at = len(self.chart) - 1  # the current location at the input
+        return [c.deduction_span(at) for c in self.chart[at]
+                if c.point.sym == self.grammar.symbols.inverse["<start>"]
+                and self.grammar.get_symbol_at_point(c.point) is None]

--- a/src/node.py
+++ b/src/node.py
@@ -1,5 +1,5 @@
 from functools import total_ordering
-from typing import Callable, Iterable, List, Tuple, Union, Self, Optional
+from typing import Iterable, List, Self, Optional
 
 
 @total_ordering
@@ -60,6 +60,7 @@ class InputString:
     """
     def __init__(self, string: str, sep: Optional[str] = None):
         split_string = string.split(sep) if sep is not None else string
+        self.sep = sep if sep is not None else ''
         self.nodes = [Terminal(x) for x in split_string]
 
 

--- a/src/test_cfg.py
+++ b/src/test_cfg.py
@@ -4,20 +4,22 @@ from unittest import TestCase
 from bidict import bidict
 
 import naive_earley as naive
+from node import NonTerminal, Terminal
 
 
 def toy_grammar() -> naive.Grammar:
+    # TODO: an efficient way of adding terminal/nonterminal automatically to the cfg
     g = naive.Grammar()
     g.add_symbol(
-        "A", False).add_symbol(
-        "a", True).add_symbol(
-        "b", True).add_symbol(
-        "c", True)
+        NonTerminal("A"), False).add_symbol(
+        Terminal("a"), True).add_symbol(
+        Terminal("b"), True).add_symbol(
+        Terminal("c"), True)
     g.add_rule(
-        ("<start>", ["A", "A"])).add_rule(
-        ("A", ["A", "a"])).add_rule(
-        ("A", ["b", "A"])).add_rule(
-        ("A", ["c"]))
+        (NonTerminal("<start>"), [NonTerminal("A"), NonTerminal("A")])).add_rule(
+        (NonTerminal("A"), [NonTerminal("A"), Terminal("a")])).add_rule(
+        (NonTerminal("A"), [Terminal("b"), NonTerminal("A")])).add_rule(
+        (NonTerminal("A"), [Terminal("c")]))
     return g
 
 
@@ -27,7 +29,13 @@ class TestGrammar(TestCase):
 
         print("SYMBOLZ:", g.fmt_all_symbols())
         print("RULEZ:", g.fmt_all_rules())
-        assert g.symbols == bidict({0: "<start>", 1: "\0", 2: "A", 3: "a", 4: "b", 5: "c"})
+        assert g.symbols == bidict({
+            0: NonTerminal("<start>"),
+            1: Terminal("\0"),
+            2: NonTerminal("A"),
+            3: Terminal("a"),
+            4: Terminal("b"),
+            5: Terminal("c")})
         assert set(g.fmt_all_rules()) == {'<start> → AA', 'A → Aa|bA|c'}
 
 

--- a/src/test_earley.py
+++ b/src/test_earley.py
@@ -66,6 +66,7 @@ class TestNaiveEarley(TestCase):
             p.feed(c)
         p.feed(Terminal("\0"))
 
+        print('CHART:')
         for k, st in enumerate(p.chart):
             st_str = set(p.grammar.fmt_point(s.point) for s in st)
             print(f"{k}\t: {st_str}")
@@ -79,6 +80,19 @@ class TestNaiveEarley(TestCase):
                 {'A → Aa•', 'A → •bA', 'A → •Aa', 'A → A•a', '<start> → A•A', 'A → •c'})
         assert (set(p.grammar.fmt_point(s.point) for s in p.chart[3]) ==
                 {'<start> → AA•', 'A → c•', 'A → A•a'})
+
+        assert ([c.fmt(p.grammar) for c in p.complete_items()] == ['<start> → AA• [0, 3)'])
+        fin = p.complete_items()[0]
+        dt_repr = p.trace_deduction(fin).fmt_tree(p.grammar, s=inp)
+        print('DERIVATION TREE:\n', '\n'.join(dt_repr))
+        assert dt_repr == [
+            "<start> → AA• [0, 3) cac",
+            "\tA → Aa• [0, 2) ca",
+            "\t\tA → c• [0, 1) c",
+            "\t\t\tc [0, 1) c",
+            "\t\ta [1, 2) a",
+            "\tA → c• [2, 3) c",
+            "\t\tc [2, 3) c"]
 
     def test_reject(self):
         grammar = toy_grammar()

--- a/src/test_earley.py
+++ b/src/test_earley.py
@@ -162,8 +162,8 @@ class TestFastEarley(TestCase):
     def test_simple(self):
         g = toy_grammar()
         p = fast.Earley(g)
-        input_strings = InputString("cac").nodes
-        for c in input_strings:
+        input_strings = InputString("cac")
+        for c in input_strings.nodes:
             p.feed(c)
         p.feed(Terminal("\0"))
 
@@ -180,6 +180,25 @@ class TestFastEarley(TestCase):
         for k, st in enumerate(p.chart):
             st_str = set(p.grammar.fmt_point(s.point) for s in st)
             print(f"{k}\t: {st_str}")
+
+        for k, v in p.deduced_by.items():
+            print(f"{k.fmt(p.grammar)} is deduced by {v.fmt(p.grammar)}")
+        assert ([c.fmt(p.grammar) for c in p.complete_items()] == ['<start> → AA• [0, 3)'])
+        fin = p.complete_items()[0]
+        dt_repr = p.trace_deduction(fin).fmt_tree(p.grammar, s=input_strings)
+        print('DERIVATION TREE:\n', '\n'.join(dt_repr))
+        assert dt_repr == [
+            "<start> → AA• [0, 3) cac",
+            "\tA★ [0, 2) ca",
+            "\t\tA → Aa• [0, 2) ca",
+            "\t\t\tA★ [0, 1) c",
+            "\t\t\t\tA → c• [0, 1) c",
+            "\t\t\t\t\tc [0, 1) c",
+            "\t\t\ta [1, 2) a",
+            "\tA★ [2, 3) c",
+            "\t\tA → c• [2, 3) c",
+            "\t\t\tc [2, 3) c",
+        ]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Here, we are adding an extra table that keeps track of which partial rule + text span was deduced by which other complete rule + text span.

Then after we are done with parsing (or at any point in the middle if we'd like to), we can build one possible deduction tree that rooted in any rule + text span (typically the starting rule + entire text span)